### PR TITLE
Bandage to keep measure from crashing for TTS not working on Android 11.

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Pixel_4_API_32.avd" />
+            <value value="$USER_HOME$/.android/avd/Pixel_6_Pro_API_30.avd" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-03-23T23:50:13.398304Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-03-24T21:17:33.942273Z" />
   </component>
 </project>

--- a/MotorControl/src/main/kotlin/org/sagebionetworks/motorcontrol/state/ActiveStep.kt
+++ b/MotorControl/src/main/kotlin/org/sagebionetworks/motorcontrol/state/ActiveStep.kt
@@ -110,7 +110,7 @@ interface ActiveStep {
             ""
         )
         /**
-         * This is to keep the measure unblocked in the case that TTS does not work
+         * If active step is finished and TTS does not work then navigate forward
          */
         if (status == TextToSpeech.ERROR) {
             goForward()

--- a/MotorControl/src/main/kotlin/org/sagebionetworks/motorcontrol/state/ActiveStep.kt
+++ b/MotorControl/src/main/kotlin/org/sagebionetworks/motorcontrol/state/ActiveStep.kt
@@ -11,7 +11,6 @@ import android.os.Looper
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import androidx.compose.runtime.MutableState
-import androidx.compose.ui.text.toLowerCase
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -104,11 +103,17 @@ interface ActiveStep {
             override fun onError(utteranceId: String?) {}
         }
         textToSpeech.setOnUtteranceProgressListener(speechListener)
-        textToSpeech.speak(
+        val status = textToSpeech.speak(
             spokenInstructions[duration.toInt()],
             TextToSpeech.QUEUE_ADD,
             null,
             ""
         )
+        /**
+         * This is to keep the measure unblocked in the case that TTS does not work
+         */
+        if (status == TextToSpeech.ERROR) {
+            goForward()
+        }
     }
 }

--- a/MotorControl/src/main/kotlin/org/sagebionetworks/motorcontrol/state/MotionSensorState.kt
+++ b/MotorControl/src/main/kotlin/org/sagebionetworks/motorcontrol/state/MotionSensorState.kt
@@ -37,8 +37,14 @@ class MotionSensorState(
     init {
         createMotionSensor()
         title = title.replace("%@", hand?.name ?: "")
+        /**
+         * This implementation of TTS does not work on Android 11. Versions before and
+         * after Android 11 do work.
+         */
         textToSpeech = TextToSpeech(context) {
-            textToSpeech.speak(spokenInstructions[0], TextToSpeech.QUEUE_ADD, null, "")
+            if (it == TextToSpeech.SUCCESS) {
+                textToSpeech.speak(spokenInstructions[0], TextToSpeech.QUEUE_ADD, null, "")
+            }
         }
     }
 

--- a/MotorControl/src/main/kotlin/org/sagebionetworks/motorcontrol/state/TappingState.kt
+++ b/MotorControl/src/main/kotlin/org/sagebionetworks/motorcontrol/state/TappingState.kt
@@ -50,8 +50,14 @@ class TappingState(
 
     init {
         createMotionSensor()
+        /**
+         * This implementation of TTS does not work on Android 11. Versions before and
+         * after Android 11 do work.
+         */
         textToSpeech = TextToSpeech(context) {
-            textToSpeech.speak(spokenInstructions[0], TextToSpeech.QUEUE_ADD, null, "")
+            if (it == TextToSpeech.SUCCESS) {
+                textToSpeech.speak(spokenInstructions[0], TextToSpeech.QUEUE_ADD, null, "")
+            }
         }
     }
 


### PR DESCRIPTION
This is a small fix to prevent measure from crashing on Android 11 due to TTS not initializing issue. After looking into this bug there does not seem to be a clear reason as to why the TextToSpeech Synthesizer does not initialize only on Android 11, but there are other instances of people having issues with Android 11 and TTS. There are no indicators as to why TTS doesn't initialize for Android 11 other than a generic status code of -1 for a fail on initialization.

Android instructs developers to include this code block into the AndroidManifest file of the app due to changes Android 11 started: 
[Documentation](https://developer.android.com/reference/android/speech/tts/TextToSpeech)

```
<queries>
  <intent>
      <action android:name="android.intent.action.TTS_SERVICE" />
  </intent>
 </queries>
```

but this does not solve the issue within the MotorControl Sample App. Therefore, a catch to keep the measures working on Android 11 without TTS is the best solution I can come up with at the moment.

